### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,18 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for interscholastic play",
+        "schedule": "Mondays, Wednesdays, Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["james@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn and practice tennis skills on the courts",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["rachel@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and other visual arts",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["isabella@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Perform in theatrical productions and improve acting skills",
+        "schedule": "Mondays and Thursdays, 4:30 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["noah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop argumentation and public speaking skills through competitive debate",
+        "schedule": "Tuesdays and Thursdays, 3:45 PM - 5:15 PM",
+        "max_participants": 16,
+        "participants": ["ava@mergington.edu", "ethan@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore various scientific disciplines",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["mia@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -25,7 +25,39 @@ document.addEventListener("DOMContentLoaded", () => {
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <h5>Participants</h5>
+            <ul class="participants-list"></ul>
+          </div>
         `;
+
+        const participantsList = activityCard.querySelector(".participants-list");
+
+        if (details.participants.length > 0) {
+          details.participants.forEach((email) => {
+            const li = document.createElement("li");
+
+            const emailSpan = document.createElement("span");
+            emailSpan.className = "participant-email";
+            emailSpan.textContent = email;
+
+            const deleteBtn = document.createElement("button");
+            deleteBtn.className = "delete-participant-btn";
+            deleteBtn.title = "Unregister participant";
+            deleteBtn.dataset.activity = name;
+            deleteBtn.dataset.email = email;
+            deleteBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"></path><path d="M10 11v6"></path><path d="M14 11v6"></path><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path></svg>`;
+
+            li.appendChild(emailSpan);
+            li.appendChild(deleteBtn);
+            participantsList.appendChild(li);
+          });
+        } else {
+          const li = document.createElement("li");
+          li.className = "no-participants";
+          li.textContent = "No participants yet — be the first!";
+          participantsList.appendChild(li);
+        }
 
         activitiesList.appendChild(activityCard);
 
@@ -62,6 +94,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +111,31 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle participant deletion
+  activitiesList.addEventListener("click", async (event) => {
+    const deleteBtn = event.target.closest(".delete-participant-btn");
+    if (!deleteBtn) return;
+
+    const activity = deleteBtn.dataset.activity;
+    const email = deleteBtn.dataset.email;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      if (response.ok) {
+        fetchActivities();
+      } else {
+        const result = await response.json();
+        console.error("Error unregistering:", result.detail);
+      }
+    } catch (error) {
+      console.error("Error unregistering:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,75 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed #c8d8f0;
+}
+
+.participants-section h5 {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #1a237e;
+  margin-bottom: 6px;
+}
+
+.participants-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px;
+  background-color: #e8eaf6;
+  border-left: 3px solid #3949ab;
+  border-radius: 3px;
+  font-size: 0.9rem;
+  color: #1a237e;
+}
+
+.participant-email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.delete-participant-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #9fa8da;
+  padding: 2px 4px;
+  border-radius: 3px;
+  margin-left: 8px;
+  line-height: 1;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.delete-participant-btn:hover {
+  color: #c62828;
+  background-color: #ffebee;
+}
+
+.participants-list li.no-participants {
+  background-color: #f5f5f5;
+  border-left-color: #bdbdbd;
+  color: #757575;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    """Reset in-memory activity data after each test."""
+    original_state = deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(deepcopy(original_state))
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,115 @@
+import src.app as app_module
+
+
+def test_get_activities_returns_seeded_data(client):
+    # Arrange
+    expected_activity_count = 9
+
+    # Act
+    response = client.get("/activities")
+
+    # Assert
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, dict)
+    assert len(payload) == expected_activity_count
+    assert "Chess Club" in payload
+    assert "participants" in payload["Chess Club"]
+
+
+def test_signup_for_activity_succeeds(client):
+    # Arrange
+    activity_name = "Science Club"
+    email = "new-student@mergington.edu"
+    initial_count = len(app_module.activities[activity_name]["participants"])
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in app_module.activities[activity_name]["participants"]
+    assert len(app_module.activities[activity_name]["participants"]) == initial_count + 1
+
+
+def test_signup_for_invalid_activity_returns_404(client):
+    # Arrange
+    invalid_activity_name = "Sky Diving"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{invalid_activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_signup_duplicate_student_returns_400(client):
+    # Arrange
+    activity_name = "Chess Club"
+    existing_email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(
+        f"/activities/{activity_name}/signup", params={"email": existing_email}
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Student already signed up for this activity"
+    }
+
+
+def test_unregister_from_activity_succeeds(client):
+    # Arrange
+    activity_name = "Basketball Team"
+    email = "james@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Unregistered {email} from {activity_name}"
+    }
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_for_invalid_activity_returns_404(client):
+    # Arrange
+    invalid_activity_name = "Underwater Basket Weaving"
+    email = "student@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{invalid_activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_unregister_non_participant_returns_400(client):
+    # Arrange
+    activity_name = "Drama Club"
+    email = "not-enrolled@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Student is not signed up for this activity"
+    }

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,80 @@
+import src.app as app_module
+
+
+def test_signup_then_unregister_workflow(client):
+    # Arrange
+    activity_name = "Debate Team"
+    email = "workflow-student@mergington.edu"
+
+    # Act
+    signup_response = client.post(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+    unregister_response = client.delete(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert signup_response.status_code == 200
+    assert unregister_response.status_code == 200
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_duplicate_signup_workflow_rejects_second_attempt(client):
+    # Arrange
+    activity_name = "Art Studio"
+    email = "duplicate-check@mergington.edu"
+
+    # Act
+    first_signup_response = client.post(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+    second_signup_response = client.post(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert first_signup_response.status_code == 200
+    assert second_signup_response.status_code == 400
+    assert second_signup_response.json() == {
+        "detail": "Student already signed up for this activity"
+    }
+    assert app_module.activities[activity_name]["participants"].count(email) == 1
+
+
+def test_multiple_students_can_signup_to_same_activity(client):
+    # Arrange
+    activity_name = "Programming Class"
+    new_students = [
+        "multi-1@mergington.edu",
+        "multi-2@mergington.edu",
+        "multi-3@mergington.edu",
+    ]
+
+    # Act
+    responses = [
+        client.post(f"/activities/{activity_name}/signup", params={"email": email})
+        for email in new_students
+    ]
+
+    # Assert
+    assert all(response.status_code == 200 for response in responses)
+    for email in new_students:
+        assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_without_signup_workflow_returns_400(client):
+    # Arrange
+    activity_name = "Tennis Club"
+    email = "never-signed-up@mergington.edu"
+
+    # Act
+    response = client.delete(
+        f"/activities/{activity_name}/signup", params={"email": email}
+    )
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Student is not signed up for this activity"
+    }


### PR DESCRIPTION
This pull request adds participant management features to the activities app, allowing users to view, sign up for, and unregister from activity rosters. It introduces backend support for unregistering, prevents duplicate signups, and updates the UI to display and manage participants interactively. Comprehensive tests are also added to ensure correct API behavior and state management.

Backend enhancements:

* Added a DELETE endpoint (`/activities/{activity_name}/signup`) to allow unregistering a participant from an activity, with validation for activity existence and participant status.
* Updated the signup logic to prevent duplicate signups by checking if the student is already registered.
* Seeded additional activities with participant lists in `src/app.py`.

Frontend improvements:

* Displayed a list of participants for each activity, including a button to unregister each participant, and handled the "no participants" case.
* Implemented participant removal via the UI, calling the new backend endpoint and refreshing the activity list on success. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R117-R141) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R97)
* Added new styles for the participants list and delete buttons for improved UI clarity.

Testing and reliability:

* Added fixtures to reset activity state between tests, ensuring test isolation.
* Implemented thorough endpoint and workflow tests for sign-up, unregister, duplicate prevention, and error handling scenarios. [[1]](diffhunk://#diff-a6c21e4e80fbff10e122c6a03d321d5a2048d51dfe555b4273e038d549123002R1-R115) [[2]](diffhunk://#diff-062d7920c867ef17e231797ab56a990f96a5beafa69c52c03fee3f19f7b19cccR1-R80)